### PR TITLE
Added mobile.twitter.com to AndroidManifest.xml

### DIFF
--- a/Tinfoil-for-Twitter/src/main/AndroidManifest.xml
+++ b/Tinfoil-for-Twitter/src/main/AndroidManifest.xml
@@ -84,6 +84,12 @@
                 <data
                     android:host="apps.twitter.com"
                     android:scheme="https"/>
+                <data
+                    android:host="mobile.twitter.com"
+                    android:scheme="http"/>
+                <data
+                    android:host="mobile.twitter.com"
+                    android:scheme="https"/>
             </intent-filter>
 
         </activity>


### PR DESCRIPTION
Sometimes twitter links may appear as mobile.twitter.com (e.g. when pasted by a person who's browsing the mobile website), these should be able to open in Tinfoil for Twitter.
